### PR TITLE
updated the contact page layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -928,9 +928,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001550",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001550.tgz",
-      "integrity": "sha512-p82WjBYIypO0ukTsd/FG3Xxs+4tFeaY9pfT4amQL8KWtYH7H9nYwReGAbMTJ0hsmRO8IfDtsS6p3ZWj8+1c2RQ==",
+      "version": "1.0.30001667",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
+      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
       "dev": true,
       "funding": [
         {
@@ -945,7 +945,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",

--- a/src/components/Contact-section/Contact-section.css
+++ b/src/components/Contact-section/Contact-section.css
@@ -1,3 +1,19 @@
+.contact-box {
+    border: 2px solid #312F2F; /* Border color */
+    border-radius: 8px; /* Optional: rounded corners */
+    background-color: #d8f1f1; /* Optional: background color */
+    
+    padding: 20px; /* Padding inside the border */
+    width: 100%; /* Full width */
+    max-width: 2000px; /* Increase the maximum width as needed */
+    margin: 0 auto; /* Center the box */
+}
+
 #ContactUs {
-    margin-bottom: 5rem;
+    margin-bottom: 0 rem; /* Further reduced margin-bottom to minimize the space */
+}
+
+main {
+    margin-top: 0; /* Remove any top margin between the Contact Us header and Contact Text */
+    padding-top: 0; /* Remove extra padding if present */
 }

--- a/src/components/Contact-section/Contact.jsx
+++ b/src/components/Contact-section/Contact.jsx
@@ -8,15 +8,17 @@ import Twitter from "../../assets/Social-Icons/Twitter.png";
 
 const Contact = () => {
   return (
-    <section className="flex flex-col w-full  px-[5%] gap-10 justify-center">
+    <section className="flex flex-col w-full px-[5%] gap-10 justify-center">
       <header id="ContactUs" className="flex justify-center align-middle mt-20">
         <h1 className="text-5xl font-bold tracking-wider text-text-black font-monsterrat">
           Contact Us
         </h1>
       </header>
-      <main className=" flex flex-wrap lg:gap-[5%] gap-[20px] justify-center items-center">
-        <ContactText />
-        <ContactForm />
+      <main className="flex flex-wrap lg:gap-[5%] gap-[20px] justify-center items-center">
+        <div className="contact-box flex flex-col md:flex-row lg:gap-[5%] gap-[20px] justify-center items-center">
+          <ContactText />
+          <ContactForm />
+        </div>
       </main>
       <div className="flex items-center justify-center p-0">
         <article className="flex flex-col items-center md:items-start text-center md:text-left">


### PR DESCRIPTION
Improve Contact Page Layout and Background

Reduce the gap between the "Contact Us" heading and the contact information for a more cohesive layout.

![Screenshot (304)](https://github.com/user-attachments/assets/c2fef4f2-c486-45c4-be3e-3ec9de786ca2)

Change the background color of the Contact page to light cyan that aligns with the theme of the other sections.