### PR TITLE
Fix Image Layout Issues on About Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3141,7 +3141,6 @@
       "version": "7.53.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
       "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },

--- a/src/components/testimonial-section/Testimonial.jsx
+++ b/src/components/testimonial-section/Testimonial.jsx
@@ -67,17 +67,25 @@ const Testimonial = () => {
           <img
             src={slides[slide - 1 < 0 ? slides.length - 1 : slide - 1].url}
             alt="image"
+            style={{ marginBottom: '0' }}   
+             /* 
+            Warning: A 60px margin is applied to all images in home.css, 
+            causing layout issues. Remove if unnecessary, 
+            or use overrides for specific components.
+            That's what I did overrided specific components becouse I don't know it that home.css code is needed or not.
+          */
+          
           />
         </div>
         <div className="flex justify-center items-center w-56 h-56 sm:w-96 sm:h-96 rounded-full overflow-hidden py-3 bg-center bg-cover duration-500 hover:scale-110 cursor-pointer">
           <img src={slides[slide].url} alt="image" />
         </div>
         <div className="flex justify-center items-center w-40 h-40 sm:w-40 sm:h-40 rounded-full overflow-hidden py-3 bg-center bg-cover duration-500">
-          <img
-            src={slides[slide + 1 > slides.length - 1 ? 0 : slide + 1].url}
-            alt="image"
-          />
+           <img src={slides[slide + 1 > slides.length - 1 ? 0 : slide + 1].url} alt="image" 
+            style={{ marginBottom: '0' }} 
+           />
         </div>
+
       </div>
       <div className="flex flex-col mx-auto w-[70%] justify-center text-center text-textWhite font-medium">
         <h2>{slides[slide].name}</h2>

--- a/src/pages/home.css
+++ b/src/pages/home.css
@@ -1,3 +1,5 @@
+/* Warning: A 60px margin is applied to all images in home.css. 
+ Remove if unnecessary, or override for specific cases. */
 img {
     margin-bottom: 60px;
 }


### PR DESCRIPTION
### 🚀 Pull Request

**Description**  
This pull request addresses the issue of improper image stretching on the About page caused by a global margin of 60px applied to images in home.css. The changes ensure that images display correctly within a circular layout, improving responsiveness on smaller screens.

---

**Related Issue**  
Closes #400

---

**Type of Change**  
What kind of change does this pull request introduce?  
- [x] 🐛 Bug fix  
- [ ] 🚀 New feature  
- [ ] 📄 Documentation update  
- [ ] 🛠️ Code improvement/refactor  
- [X] 🖼️ UI/UX update  
- [ ] Other (please specify)

---

**Screenshots (if applicable)**  

**before** 
![WhatsApp Image 2024-10-17 at 3 36 30 PM](https://github.com/user-attachments/assets/936a65a3-81a4-4a2b-9271-78c943c48338)

**After**
![Screenshot from 2024-10-17 17-57-58](https://github.com/user-attachments/assets/3f6533db-25fb-4d0f-bfb8-2703ae16069a)


---

**Checklist**  
Please ensure the following tasks are complete before submitting the pull request:  
- [x] I have tested my changes and ensured they work as expected.  
- [x] I have added any necessary documentation or comments.  
- [x] I have checked the existing issues and pull requests to avoid duplicates.  
- [x] I have **starred this repository**.  
- [x] I have reviewed my code for best practices and readability.  
- [ ] I have included any relevant tests (if applicable).

---

**Additional Context**  
This pull request addresses a layout issue caused by a global margin applied to images in `home.css`. The margin affected the circular image display in the testimonial section, leading to improper stretching. 

By adding overrides and adjusting the styles, the images now display correctly and are fully responsive across different screen sizes. The fix also includes code refactoring for better maintainability, ensuring that future changes will be easier to manage.

