### PR TITLE
Added Issue Labeler GitHub Action

### DIFF
--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -1,0 +1,66 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  manage-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Create or Update Labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "gssoc-ext",
+              "color": "0e4075",
+              "description": "GSSOC extended contribution"
+            }'
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "hacktoberfest",
+              "color": "006b75",
+              "description": "Hacktoberfest participation"
+            }'
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "hacktoberfest-accepted",
+              "color": "95d2aa",
+              "description": "Hacktoberfest contribution accepted"
+            }'
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "level?",
+              "color": "5319e7",
+              "description": "Placeholder for difficulty level"
+            }'
+
+      - name: Add Labels to Issue
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            gssoc-ext
+            hacktoberfest
+            hacktoberfest-accepted
+            level?


### PR DESCRIPTION
# PR Title:  
Added Issue Labeler GitHub Action

## Description:  
This PR adds a GitHub Action to automate labeling of issues on creation or edit.  
The labels added are `gssoc-extd` (green), `hacktoberfest` (orange), and `level?` (purple).  
`level?` serves as a placeholder until the project admin assigns the final level during PR review.  
The workflow uses the GitHub API to ensure labels are updated with correct colors and descriptions

Fix #457 

@gauravsingh1281 
Pls add labels like level2,gssoc-extd,hacktoberfest-accepted.