### PR TITLE
fix: remove unused RentCalculator import from Home page

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,7 +2,6 @@ import AboutUs from "../components/AboutUs-section/AboutUs";
 import Contributors from "../components/Contributors-page/Contributors";
 import Contact from "../components/Contact-section/Contact";
 import FAQ from "../components/faq/FAQ";
-import RentCalculator from "../components/rent/RentCalculator";
 import Footer from "../components/Footer-section/Footer";
 import Header from "../components/Header-section/Header";
 import Services from "../components/Services-section/Services-section";


### PR DESCRIPTION
Closes #691

The RentCalculator link was previously removed from the navbar in a prior refactor. This PR cleans up the remaining unused import from Home.jsx.