### PR TITLE
feat: add certificate of contribution for contributors

### DIFF
--- a/src/components/Contributors-page/Contributors.css
+++ b/src/components/Contributors-page/Contributors.css
@@ -228,3 +228,139 @@ body {
     max-width: 97%;
   }
 }
+
+.certificate-btn {
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  background: linear-gradient(135deg, #0077b6, #00b4d8);
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.certificate-btn:hover {
+  transform: scale(1.05);
+  box-shadow: 0 2px 8px rgba(0, 119, 182, 0.4);
+}
+
+.certificate-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  padding: 1rem;
+}
+
+.certificate-modal {
+  max-width: 500px;
+  width: 100%;
+}
+
+.certificate-content {
+  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  border: 3px solid #e94560;
+  border-radius: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.certificate-title {
+  color: #e94560;
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.certificate-subtitle {
+  color: #ffffff;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.certificate-name {
+  color: #f5c518;
+  font-size: 1.75rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.certificate-desc {
+  color: #ffffff;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.certificate-project {
+  color: #4facfe;
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.certificate-stats {
+  color: #cccccc;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.certificate-repo {
+  color: #aaaaaa;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.certificate-date {
+  color: #aaaaaa;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.certificate-footer {
+  color: #e94560;
+  font-size: 0.9rem;
+  margin-top: 1rem;
+}
+
+.certificate-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.certificate-download-btn {
+  padding: 0.5rem 1rem;
+  background: linear-gradient(135deg, #0077b6, #00b4d8);
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.certificate-download-btn:hover {
+  transform: scale(1.05);
+}
+
+.certificate-close-btn {
+  padding: 0.5rem 1rem;
+  background: #6b7280;
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.certificate-close-btn:hover {
+  transform: scale(1.05);
+}

--- a/src/components/Contributors-page/Contributors.jsx
+++ b/src/components/Contributors-page/Contributors.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import axios from "axios";
 import "./Contributors.css";
 
@@ -7,6 +7,8 @@ function Contributors() {
   const [repoStats, setRepoStats] = useState({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [selectedContributor, setSelectedContributor] = useState(null);
+  const certificateRef = useRef(null);
 
   useEffect(() => {
     async function fetchContributors() {
@@ -56,6 +58,89 @@ function Contributors() {
     0
   );
 
+  const downloadCertificate = useCallback(() => {
+    if (!selectedContributor || !certificateRef.current) return;
+
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    const width = 800;
+    const height = 600;
+    canvas.width = width;
+    canvas.height = height;
+
+    const gradient = ctx.createLinearGradient(0, 0, width, height);
+    gradient.addColorStop(0, "#1a1a2e");
+    gradient.addColorStop(0.5, "#16213e");
+    gradient.addColorStop(1, "#0f3460");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.strokeStyle = "#e94560";
+    ctx.lineWidth = 4;
+    ctx.strokeRect(20, 20, width - 40, height - 40);
+
+    ctx.fillStyle = "#e94560";
+    ctx.font = "bold 36px serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Certificate of Contribution", width / 2, 100);
+
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "18px sans-serif";
+    ctx.fillText("This certifies that", width / 2, 170);
+
+    ctx.fillStyle = "#f5c518";
+    ctx.font = "bold 32px serif";
+    ctx.fillText(selectedContributor.login, width / 2, 230);
+
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "18px sans-serif";
+    ctx.fillText(
+      "has made valuable contributions to",
+      width / 2,
+    280
+    );
+
+    ctx.fillStyle = "#4facfe";
+    ctx.font = "bold 24px sans-serif";
+    ctx.fillText("Rentalog.in", width / 2, 330);
+
+    ctx.fillStyle = "#cccccc";
+    ctx.font = "16px sans-serif";
+    ctx.fillText(
+      `${selectedContributor.contributions} contribution(s)`,
+      width / 2,
+      380
+    );
+
+    ctx.fillStyle = "#aaaaaa";
+    ctx.font = "14px sans-serif";
+    ctx.fillText(
+      `Repository: gauravsingh1281/Rentalog.in--Frontend`,
+      width / 2,
+      430
+    );
+
+    const date = new Date().toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    ctx.fillText(`Date: ${date}`, width / 2, 470);
+
+    ctx.fillStyle = "#e94560";
+    ctx.font = "14px sans-serif";
+    ctx.fillText(
+      "Thank you for your contribution!",
+      width / 2,
+      530
+    );
+
+    const link = document.createElement("a");
+    link.download = `certificate-${selectedContributor.login}.png`;
+    link.href = canvas.toDataURL("image/png");
+    link.click();
+  }, [selectedContributor]);
+
   return (
     <div className="contributors-container">
       <h1 className="contributors-title">Our Contributors</h1>
@@ -104,12 +189,66 @@ function Contributors() {
               <p className="contributor-contributions">
                 Contributions: {contributor.contributions}
               </p>
+              <button
+                className="certificate-btn"
+                onClick={() => setSelectedContributor(contributor)}
+              >
+                Get Certificate
+              </button>
             </div>
           ))
         ) : (
           <p>No contributors found.</p>
         )}
       </div>
+
+      {/* Certificate Modal */}
+      {selectedContributor && (
+        <div className="certificate-overlay" onClick={() => setSelectedContributor(null)}>
+          <div className="certificate-modal" onClick={(e) => e.stopPropagation()}>
+            <div ref={certificateRef} className="certificate-content">
+              <div className="certificate-border">
+                <div className="certificate-inner">
+                  <h1 className="certificate-title">Certificate of Contribution</h1>
+                  <p className="certificate-subtitle">This certifies that</p>
+                  <h2 className="certificate-name">{selectedContributor.login}</h2>
+                  <p className="certificate-desc">
+                    has made valuable contributions to
+                  </p>
+                  <h3 className="certificate-project">Rentalog.in</h3>
+                  <p className="certificate-stats">
+                    {selectedContributor.contributions} contribution(s)
+                  </p>
+                  <p className="certificate-repo">
+                    Repository: gauravsingh1281/Rentalog.in--Frontend
+                  </p>
+                  <p className="certificate-date">
+                    Date: {new Date().toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </p>
+                  <p className="certificate-footer">
+                    Thank you for your contribution!
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="certificate-actions">
+              <button className="certificate-download-btn" onClick={downloadCertificate}>
+                Download Certificate
+              </button>
+              <button
+                className="certificate-close-btn"
+                onClick={() => setSelectedContributor(null)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Added a 'Get Certificate' button on each contributor card that generates and downloads a personalized certificate of contribution using Canvas API (no new dependencies).

Closes #698