### PR TITLE
fix: improve dark mode text visibility on homepage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,12 +36,44 @@ body.dark {
 }
 
 body.dark .header-text {
-    color: rgb(68, 66, 66);
-    /* Change 'grey' to your desired shade, e.g., '#808080' */
+    color: #e0e0e0;
 }
 
-body.dark nav {
-    background-color: grey;
+body.dark nav:not(.bg-\\[\\#1ABC9C\\]) {
+    background-color: #1e1e1e;
+}
+
+body.dark .header-desc {
+    color: #cccccc;
+}
+
+body.dark .contributors-container {
+    background-color: #121212;
+}
+
+body.dark .contributors-container .repo-stats-section {
+    background-color: #1e1e1e;
+}
+
+body.dark .contributors-container .repo-stats-section h3 {
+    color: #aaaaaa;
+}
+
+body.dark .contributors-container .repo-stats-section p {
+    color: #ffffff;
+}
+
+body.dark .contributor-card {
+    background-color: #2a2a3e;
+    border-color: #4a4a8e;
+}
+
+body.dark .contributor-name {
+    color: #ffffff;
+}
+
+body.dark .contributor-contributions {
+    color: #90caf9;
 }
 
 

--- a/src/components/Services-section/ServicesCard.jsx
+++ b/src/components/Services-section/ServicesCard.jsx
@@ -88,14 +88,14 @@ const ServicesCard = (props) => {
         <div className="flex gap-4 p-8">
           <img className="w-10 h-10 mt-1.5" src={props.icon} alt={props.alt} />
           <h1
-            className="text-black font-bold md:text-2xl text-xl"
+            className="text-black dark:text-white font-bold md:text-2xl text-xl"
             style={{ textShadow: "1px 1px 2.5px white" }}
           >
             {props.title}
           </h1>
         </div>
         <p
-          className="px-8 pb-20 text-black font-semibold"
+          className="px-8 pb-20 text-black dark:text-white font-semibold"
           style={{ textShadow: "1px 1px 2.5px white" }}
         >
           {props.description}


### PR DESCRIPTION
Fixed text visibility issues in dark mode across homepage and contributors page sections.

- Changed header-text from #444244 (invisible on dark background) to #e0e0e0
- Added dark:text-white to ServicesCard title and description
- Added dark mode styles for Contributors page components
- Restructured App.css dark mode section for clarity

Closes #717